### PR TITLE
Fix header comment in zipf.h

### DIFF
--- a/zipf.h
+++ b/zipf.h
@@ -1,4 +1,4 @@
-// zipf_accelerated.h - Redesigned for actual performance impact
+// zipf.h - Redesigned for actual performance impact
 #pragma once
 
 #include "llama-vocab.h"


### PR DESCRIPTION
## Summary
- correct first line in `zipf.h` to reference `zipf.h`

## Testing
- `g++ -std=c++17 -c zipfEngine.cpp` *(fails: llama.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844589c60f88324ba7cad7939538120