### PR TITLE
Track token usage between turns

### DIFF
--- a/zipf.h
+++ b/zipf.h
@@ -222,6 +222,20 @@ public:
         }
     }
 
+    // Record a generated sequence for adaptive state updates
+    void record_generation(const std::vector<llama_token>& tokens) {
+        // Track length history for complexity adjustments
+        conv_state.recent_lengths.push_back(tokens.size());
+        if (conv_state.recent_lengths.size() > 5) {
+            conv_state.recent_lengths.pop_front();
+        }
+
+        // Update token usage counts
+        for (llama_token t : tokens) {
+            conv_state.turn_frequencies[t] += 1.0f;
+        }
+    }
+
 private:
     std::string to_lower(const std::string& s) const {
         std::string result = s;

--- a/zipfEngine.cpp
+++ b/zipfEngine.cpp
@@ -440,9 +440,12 @@ int main(int argc, char** argv) {
         auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
         double elapsed_sec = elapsed_ms / 1000.0;
         double tokens_per_sec = (elapsed_sec > 0.0) ? (assistant_tokens.size() / elapsed_sec) : 0.0;
-        std::string gen_stats = "[Gen " + std::to_string(elapsed_ms) + " ms | " 
+        std::string gen_stats = "[Gen " + std::to_string(elapsed_ms) + " ms | "
                                 + std::to_string(tokens_per_sec) + " tok/s]\n";
         log_and_print(gen_stats);
+
+        // Update Zipf conversation state with generated tokens
+        zipf.record_generation(assistant_tokens);
 
         // Save conversation
         std::ofstream outfile("lastPrompt.txt", std::ios::app);


### PR DESCRIPTION
## Summary
- track conversation length and token frequencies in `ZipfAccelerator`
- update conversation state each time a response is produced

## Testing
- `g++ -std=c++17 -fsyntax-only zipfEngine.cpp` *(fails: llama.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844584c46608324af71799b51a003e7