### PR TITLE
Improve thread usage default

### DIFF
--- a/readMe.txt
+++ b/readMe.txt
@@ -50,6 +50,9 @@ A C++ project for advanced, real-time non-player character (NPC) dialogue powere
     g++ -O2 -std=c++17 rolled.cpp -o npc_dialogue -Iinclude -Llibs -lllama
     ./npc_dialogue
     ```
+    The engine now prints how many CPU threads are being used. If your system
+    reports no hardware concurrency, it defaults to at least four threads for
+    better performance.
 
 ---
 

--- a/zipfEngine.cpp
+++ b/zipfEngine.cpp
@@ -252,8 +252,11 @@ int main(int argc, char** argv) {
     }
 
     llama_context_params ctx_params = llama_context_default_params();
-    ctx_params.n_threads = std::thread::hardware_concurrency();
-    ctx_params.n_threads_batch = std::thread::hardware_concurrency();
+    unsigned int hw_threads = std::thread::hardware_concurrency();
+    if (hw_threads == 0) hw_threads = 4; // Fallback when detection fails
+    ctx_params.n_threads = std::max(4u, hw_threads);
+    ctx_params.n_threads_batch = ctx_params.n_threads;
+    std::cout << "Using " << ctx_params.n_threads << " threads\n";
     ctx_params.n_ctx = DEFAULT_N_CTX;
     ctx_params.flash_attn = false; // Disable flash attention for CPU build
 


### PR DESCRIPTION
## Summary
- ensure we use at least four threads when hardware_concurrency is unreliable
- show the number of threads in output
- document default thread behaviour in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684742efc2908324a7dfc1996b9cd9e2